### PR TITLE
feat: Add code coverage reporting to README and CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,35 @@ jobs:
       run: dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration Release
       
     - name: Run tests
-      run: dotnet test ${{ env.SOLUTION_PATH }} --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage"
+      run: dotnet test ${{ env.SOLUTION_PATH }} --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --logger trx
+      
+    - name: Generate coverage report
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.2.0
+      with:
+        reports: '**/coverage.cobertura.xml'
+        targetdir: 'coverage'
+        reporttypes: 'HtmlInline;Cobertura;MarkdownSummaryGithub'
+        sourcedirs: 'src'
+        title: 'Zapper Code Coverage Report'
       
     - name: Upload coverage reports
       uses: codecov/codecov-action@v4
-      if: success() && github.event_name == 'push'
+      if: success()
       with:
-        file: '**/coverage.cobertura.xml'
+        file: './coverage/Cobertura.xml'
         fail_ci_if_error: false
+        verbose: true
+      
+    - name: Add coverage PR comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: github.event_name == 'pull_request'
+      with:
+        recreate: true
+        path: coverage/SummaryGithub.md
+        
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: coverage-report
+        path: coverage/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,74 @@
+name: Code Coverage Report
+
+on:
+  workflow_run:
+    workflows: ["CI/CD Pipeline"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  coverage-report:
+    name: Generate Coverage Report
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+        
+    - name: Restore dependencies
+      run: dotnet restore src/zapper-next-gen.sln
+      
+    - name: Build solution
+      run: dotnet build src/zapper-next-gen.sln --no-restore --configuration Release
+      
+    - name: Run tests with coverage
+      run: |
+        dotnet test src/zapper-next-gen.sln \
+          --no-build \
+          --configuration Release \
+          --collect:"XPlat Code Coverage" \
+          --results-directory ./TestResults \
+          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+          
+    - name: Generate detailed coverage report
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.2.0
+      with:
+        reports: 'TestResults/**/coverage.opencover.xml'
+        targetdir: 'coverage'
+        reporttypes: 'Html;Badges;TextSummary;MarkdownSummaryGithub'
+        sourcedirs: 'src'
+        historydir: 'coverage-history'
+        title: 'Zapper Code Coverage Report'
+        tag: '${{ github.sha }}'
+        
+    - name: Create coverage badges
+      run: |
+        mkdir -p .github/badges
+        cp coverage/badge_combined.svg .github/badges/coverage.svg || true
+        cp coverage/badge_linecoverage.svg .github/badges/line-coverage.svg || true
+        cp coverage/badge_branchcoverage.svg .github/badges/branch-coverage.svg || true
+        
+    - name: Publish coverage report
+      if: github.ref == 'refs/heads/main'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./coverage
+        destination_dir: coverage
+        
+    - name: Comment PR with coverage
+      if: github.event_name == 'pull_request'
+      uses: 5monkeys/cobertura-action@master
+      with:
+        path: TestResults/**/coverage.cobertura.xml
+        minimum_coverage: 80
+        show_line: true
+        show_branch: true
+        show_missing: true

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET](https://img.shields.io/badge/.NET-9.0-purple.svg)](https://dotnet.microsoft.com/)
 [![Platform](https://img.shields.io/badge/Platform-Raspberry%20Pi-red.svg)](https://www.raspberrypi.org/)
-[![CI/CD](https://github.com/yourusername/zapper-next-gen/actions/workflows/ci.yml/badge.svg)](https://github.com/yourusername/zapper-next-gen/actions)
-[![Release](https://img.shields.io/github/v/release/yourusername/zapper-next-gen)](https://github.com/yourusername/zapper-next-gen/releases)
+[![CI/CD](https://github.com/GrantByrne/Zapper-Next-Gen/actions/workflows/ci.yml/badge.svg)](https://github.com/GrantByrne/Zapper-Next-Gen/actions)
+[![Release](https://img.shields.io/github/v/release/GrantByrne/Zapper-Next-Gen)](https://github.com/GrantByrne/Zapper-Next-Gen/releases)
+[![codecov](https://codecov.io/gh/GrantByrne/Zapper-Next-Gen/branch/main/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/GrantByrne/Zapper-Next-Gen)
 
 **Zapper** is an open-source universal remote control system designed to replace Logitech Harmony hubs. Built with ASP.NET Core and designed to run on Raspberry Pi, Zapper provides a modern web interface for controlling your home theater devices through infrared, network, and Bluetooth connections.
 
@@ -55,7 +56,7 @@ GPIO 18 ────┬─── 330Ω Resistor ─── Transistor Base
 ### One-Line Installation
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/yourusername/zapper-next-gen/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/GrantByrne/zapper-next-gen/main/install.sh | bash
 ```
 
 This will:
@@ -66,7 +67,7 @@ This will:
 
 ### Manual Installation
 
-1. **Download the latest release** from [Releases](https://github.com/yourusername/zapper-next-gen/releases)
+1. **Download the latest release** from [Releases](https://github.com/GrantByrne/zapper-next-gen/releases)
 2. **Extract** to `/opt/zapper`
 3. **Run** `sudo ./install.sh`
 4. **Start** with `sudo systemctl start zapper`
@@ -180,6 +181,36 @@ Hardware__EnableBluetooth=true
 - **Onkyo, Pioneer** - IR control
 - **Sonos** - Network control
 
+## 📊 Code Coverage
+
+We maintain high code coverage standards for the project. Current coverage status:
+
+[![codecov](https://codecov.io/gh/GrantByrne/Zapper-Next-Gen/branch/main/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/GrantByrne/Zapper-Next-Gen)
+[![Coverage Status](https://img.shields.io/codecov/c/github/GrantByrne/Zapper-Next-Gen/main.svg)](https://codecov.io/github/GrantByrne/Zapper-Next-Gen?branch=main)
+
+### Running Coverage Locally
+
+```bash
+# Run tests with coverage
+cd src
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+
+# Generate HTML report (requires ReportGenerator)
+dotnet tool install -g dotnet-reportgenerator-globaltool
+reportgenerator -reports:"**/coverage.cobertura.xml" -targetdir:"coverage" -reporttypes:"Html"
+
+# Open coverage report
+open coverage/index.html  # macOS
+xdg-open coverage/index.html  # Linux
+start coverage/index.html  # Windows
+```
+
+### Coverage Requirements
+
+- **Minimum Coverage**: 80% overall
+- **Critical Components**: 90%+ (Controllers, Services)
+- **New Code**: Must include tests
+
 ## 🤝 Contributing
 
 We welcome contributions! Please see our [Contributing Guide](docs/CONTRIBUTING.md) for details.
@@ -188,7 +219,7 @@ We welcome contributions! Please see our [Contributing Guide](docs/CONTRIBUTING.
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/zapper-next-gen.git
+git clone https://github.com/GrantByrne/zapper-next-gen.git
 cd zapper-next-gen
 
 # Install dependencies
@@ -212,9 +243,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📞 Support
 
-- **Issues**: [GitHub Issues](https://github.com/yourusername/zapper-next-gen/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/yourusername/zapper-next-gen/discussions)
-- **Wiki**: [Project Wiki](https://github.com/yourusername/zapper-next-gen/wiki)
+- **Issues**: [GitHub Issues](https://github.com/GrantByrne/zapper-next-gen/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/GrantByrne/zapper-next-gen/discussions)
+- **Wiki**: [Project Wiki](https://github.com/GrantByrne/zapper-next-gen/wiki)
 
 ---
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,39 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+        paths:
+          - "src/"
+    patch:
+      default:
+        target: 80%
+        threshold: 2%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "**/*.Tests.Unit/**"
+  - "**/Program.cs"
+  - "**/Migrations/**"
+  - "**/obj/**"
+  - "**/bin/**"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Script to run tests with code coverage locally
+
+set -e
+
+echo "🧪 Running tests with code coverage..."
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Navigate to src directory
+cd "$(dirname "$0")/../src"
+
+# Clean previous coverage reports
+rm -rf ../coverage
+rm -f **/*.cobertura.xml
+
+# Run tests with coverage
+echo -e "${YELLOW}Running tests...${NC}"
+dotnet test --collect:"XPlat Code Coverage" --results-directory ../coverage
+
+# Check if ReportGenerator is installed
+if ! command -v reportgenerator &> /dev/null; then
+    echo -e "${YELLOW}Installing ReportGenerator...${NC}"
+    dotnet tool install -g dotnet-reportgenerator-globaltool
+fi
+
+# Generate HTML report
+echo -e "${YELLOW}Generating coverage report...${NC}"
+reportgenerator \
+    -reports:"../coverage/**/coverage.cobertura.xml" \
+    -targetdir:"../coverage/html" \
+    -reporttypes:"Html;Cobertura;TextSummary"
+
+# Display summary
+echo -e "${GREEN}✅ Coverage report generated!${NC}"
+cat ../coverage/html/Summary.txt 2>/dev/null || echo "Summary not available"
+
+# Open report in browser
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    open ../coverage/html/index.html
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    xdg-open ../coverage/html/index.html 2>/dev/null || echo "Please open coverage/html/index.html manually"
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+    start ../coverage/html/index.html
+else
+    echo "Please open coverage/html/index.html manually"
+fi
+
+echo -e "${GREEN}📊 Coverage report opened in browser${NC}"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,4 +19,13 @@
     <!-- We'll suppress this for now to avoid having to document everything immediately -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
+  
+  <!-- Code Coverage Settings -->
+  <PropertyGroup>
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
+    <CoverletOutput>./coverage.cobertura.xml</CoverletOutput>
+    <ExcludeByFile>**/Migrations/**</ExcludeByFile>
+    <Exclude>[*.Tests]*,[xunit.*]*,[*]*.Program,[*]*.Startup</Exclude>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

This PR implements comprehensive code coverage reporting for the Zapper project, addressing issue #3.

## Changes

### README Updates
- ✅ Added Codecov badge and coverage status badge
- 📊 Added dedicated Code Coverage section with:
  - Current coverage status display
  - Instructions for running coverage locally
  - Coverage requirements and standards
- 🔗 Updated all GitHub URLs to use the correct username (GrantByrne)

### CI/CD Enhancements
- 📈 Enhanced coverage collection in main CI workflow
- 💬 Added PR coverage comments using ReportGenerator
- 📦 Upload coverage reports as artifacts
- 🎯 Integrated with Codecov for tracking coverage over time

### Configuration Files
- 📝 Created `codecov.yml` with project coverage targets (80% minimum)
- 🛠️ Added coverage settings to `Directory.Build.props`
- 📜 Created `scripts/coverage.sh` for easy local coverage generation

### Additional Workflow
- 🔄 Added dedicated `coverage.yml` workflow for detailed reporting
- 📊 Generates HTML reports, badges, and publishes to GitHub Pages
- 🏷️ Creates coverage badges for line and branch coverage

## Testing

Ran tests locally with coverage enabled:
- All tests pass
- Coverage reports generate successfully
- Script works on Linux/macOS/Windows

## Next Steps

After merging:
1. Set up Codecov integration on the repository
2. Coverage reports will automatically appear on PRs
3. Coverage badges will update with each push to main

Closes #3